### PR TITLE
Update base docs URL for v10

### DIFF
--- a/src/m_toolbar.user.js
+++ b/src/m_toolbar.user.js
@@ -756,7 +756,7 @@ EmbedCodeOnPage(function () {
 
                         ReplaceMarkdown(
                           'Mathematica Function (like Integrate, Plot, ..)',
-                          '[`#INPUT#`](http://reference.wolfram.com/mathematica/ref/#INPUT#.html)',
+                          '[`#INPUT#`](http://reference.wolfram.com/language/ref/#INPUT#.html)',
                           function(answer){ return answer.replace(/^`(.*)`$/g, "\$1" ); })
 
                     }


### PR DESCRIPTION
Use reference.wolfram.com/language/ref/ as the base documentation URL.
