### PR TITLE
Fixed messages not being handled properly

### DIFF
--- a/src/m_toolbar.user.js
+++ b/src/m_toolbar.user.js
@@ -655,13 +655,17 @@ EmbedCodeOnPage(function () {
                     }
 
                     var text = "";
-                    var inoutregex = /(In\[\d+\]:=[ \n]|Out\[\d+\](?:\/\/(?:(?:Standard|Full|Input|Output|Traditional|TeX|MathMLTree|Scientific|Engineering|Accounting)Form|Short|Shallow))?=[ \n])/g;
+                    var inoutregex = /(In\[\d+\]:=[ \n]|Out\[\d+\](?:\/\/(?:(?:Standard|Full|Input|Output|Traditional|TeX|MathMLTree|Scientific|Engineering|Accounting)Form|Short|Shallow))?=[ \n]|During evaluation of In\[\d+\]:=[ \n])/g;
                     var state = "I", type, last = 0, hasMore = true;
                     while (hasMore) {
                         if ((match = inoutregex.exec(orig))) {
                             text += orig.slice(last, match.index);
                             last = inoutregex.lastIndex;
                             type = match[0].substr(0, 1);
+
+                            if ((type == "D")) {
+                                type = "O";
+                            }
 
                             // End Output cell
                             if ((state == "O")) {


### PR DESCRIPTION
This ensures that messages are formatted properly as output.
Consider e.g. the following input:

```wl
In[283]:= a[[3]]

During evaluation of In[283]:= Part::partd: Part specification a[[3]] is longer than depth of object.

Out[283]= a[[3]]
```

**Without this change:**

```wl
a[[3]]

During evaluation of Part::partd: Part specification a[[3]] is longer than depth of object.
(* a[[3]] *)
```

**With this change:**

```wl
a[[3]]
(* Part::partd: Part specification a[[3]] is longer than depth of object. *)
(* a[[3]] *)
```

### How it works
The change is pretty straightforward: I have added a third alternative to the regex matching the In/Out labels (`inoutregex`) to handle lines with `During evaluation of In\[\d+\]:=[ \n]`. The `type` is then simply set to `O` (i.e. Output) for these lines, ensuring they are properly formatted.